### PR TITLE
Fix line endings, improve error reporting

### DIFF
--- a/backend/src/utils/csv_parser.cpp
+++ b/backend/src/utils/csv_parser.cpp
@@ -54,6 +54,8 @@ bool CSVParser::has_one_item(std::string line, std::string delimiter) {
 std::string CSVParser::get_next_line() {
 	std::string line;
 	std::getline(this->file_m, line);
+	if(line.back() == '\r')
+		line.pop_back();
 	return line;
 }
 


### PR DESCRIPTION
Essentially, CRLF ending reference files cause problems because the residual carriage return isn't expected. I added an if statement to remove the last character of a line if it is a carriage return (because the line feed is automatically removed).